### PR TITLE
Add layout persistence

### DIFF
--- a/Sources/AppBundle/initAppBundle.swift
+++ b/Sources/AppBundle/initAppBundle.swift
@@ -22,8 +22,9 @@ import Foundation
         Workspace.garbageCollectUnusedWorkspaces() // init workspaces
         _ = Workspace.all.first?.focusWorkspace()
         try await runRefreshSessionBlocking(.startup, layoutWorkspaces: false)
+        let restored = await restoreWorldState()
         try await runSession(.startup, .checkServerIsEnabledOrDie) {
-            smartLayoutAtStartup()
+            if !restored { smartLayoutAtStartup() }
             _ = try await config.afterStartupCommand.runCmdSeq(.defaultEnv, .emptyStdin)
         }
     }

--- a/Sources/AppBundle/layout/refresh.swift
+++ b/Sources/AppBundle/layout/refresh.swift
@@ -42,6 +42,7 @@ func runRefreshSessionBlocking(
             updateTrayText()
             try await normalizeLayoutReason()
             if shouldLayoutWorkspaces { try await layoutWorkspaces() }
+            saveWorldState()
         }
     }
 }
@@ -76,6 +77,7 @@ func runSession<T>(
             if focusBefore != focusAfter {
                 focusAfter?.nativeFocus() // syncFocusToMacOs
             }
+            saveWorldState()
             runRefreshSession(event, screenIsDefinitelyUnlocked: false)
             return result
         }

--- a/Sources/AppBundle/tree/TilingContainer.swift
+++ b/Sources/AppBundle/tree/TilingContainer.swift
@@ -55,7 +55,7 @@ extension TilingContainer {
     }
 }
 
-enum Layout: String {
+enum Layout: String, Codable {
     case tiles
     case accordion
 }

--- a/Sources/AppBundle/tree/frozen/FrozenWorld.swift
+++ b/Sources/AppBundle/tree/frozen/FrozenWorld.swift
@@ -1,4 +1,4 @@
-struct FrozenWorld {
+struct FrozenWorld: Codable {
     let workspaces: [FrozenWorkspace]
     let monitors: [FrozenMonitor]
     let windowIds: Set<UInt32>
@@ -8,6 +8,15 @@ struct FrozenWorld {
         self.monitors = monitors
         self.windowIds = workspaces.flatMap { collectAllWindowIds(workspace: $0) }.toSet()
     }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        workspaces = try container.decode([FrozenWorkspace].self, forKey: .workspaces)
+        monitors = try container.decode([FrozenMonitor].self, forKey: .monitors)
+        windowIds = workspaces.flatMap { collectAllWindowIds(workspace: $0) }.toSet()
+    }
+
+    private enum CodingKeys: String, CodingKey { case workspaces, monitors }
 }
 
 private func collectAllWindowIds(workspace: FrozenWorkspace) -> [UInt32] {

--- a/Sources/AppBundle/tree/frozen/closedWindowsCache.swift
+++ b/Sources/AppBundle/tree/frozen/closedWindowsCache.swift
@@ -8,7 +8,7 @@ import AppKit
 /// so that once the screen is unlocked, AeroSpace could restore windows to where they were
 @MainActor private var closedWindowsCache = FrozenWorld(workspaces: [], monitors: [])
 
-struct FrozenMonitor: Sendable {
+struct FrozenMonitor: Codable, Sendable {
     let topLeftCorner: CGPoint
     let visibleWorkspace: String
 
@@ -18,7 +18,7 @@ struct FrozenMonitor: Sendable {
     }
 }
 
-struct FrozenWorkspace: Sendable {
+struct FrozenWorkspace: Codable, Sendable {
     let name: String
     let monitor: FrozenMonitor // todo drop this property, once monitor to workspace assignment migrates to TreeNode
     let rootTilingNode: FrozenContainer

--- a/Sources/AppBundle/tree/workspaceState.swift
+++ b/Sources/AppBundle/tree/workspaceState.swift
@@ -1,0 +1,75 @@
+import AppKit
+import Foundation
+import Common
+
+private let workspaceStateFile = URL(filePath: "/tmp/\(aeroSpaceAppId)-workspace-state.json")
+
+@MainActor
+func saveWorldState() {
+    let world = FrozenWorld(
+        workspaces: Workspace.all.map { FrozenWorkspace($0) },
+        monitors: monitors.map(FrozenMonitor.init)
+    )
+    guard let data = JSONEncoder.aeroSpaceDefault.encodeToString(world)?.data(using: .utf8) else { return }
+    try? data.write(to: workspaceStateFile)
+}
+
+@MainActor
+@discardableResult
+func restoreWorldState() async -> Bool {
+    guard let data = try? Data(contentsOf: workspaceStateFile) else { return false }
+    guard let world = try? JSONDecoder().decode(FrozenWorld.self, from: data) else { return false }
+    let monitors = monitors
+    let topLeftCornerToMonitor = monitors.grouped { $0.rect.topLeftCorner }
+    for frozenWorkspace in world.workspaces {
+        let workspace = Workspace.get(byName: frozenWorkspace.name)
+        _ = topLeftCornerToMonitor[frozenWorkspace.monitor.topLeftCorner]?
+            .singleOrNil()?
+            .setActiveWorkspace(workspace)
+        for frozenWindow in frozenWorkspace.floatingWindows {
+            MacWindow.get(byId: frozenWindow.id)?.bindAsFloatingWindow(to: workspace)
+        }
+        for frozenWindow in frozenWorkspace.macosUnconventionalWindows {
+            MacWindow.get(byId: frozenWindow.id)?.bindAsFloatingWindow(to: workspace)
+        }
+        let prevRoot = workspace.rootTilingContainer
+        let potentialOrphans = prevRoot.allLeafWindowsRecursive
+        prevRoot.unbindFromParent()
+        restoreTreeRecursiveAllowMissing(frozenContainer: frozenWorkspace.rootTilingNode, parent: workspace, index: INDEX_BIND_LAST)
+        for window in (potentialOrphans - workspace.rootTilingContainer.allLeafWindowsRecursive) {
+            try? await window.relayoutWindow(on: workspace, forceTile: true)
+        }
+    }
+    for monitor in world.monitors {
+        _ = topLeftCornerToMonitor[monitor.topLeftCorner]?
+            .singleOrNil()?
+            .setActiveWorkspace(Workspace.get(byName: monitor.visibleWorkspace))
+    }
+    return true
+}
+
+@MainActor
+private func restoreTreeRecursiveAllowMissing(
+    frozenContainer: FrozenContainer,
+    parent: NonLeafTreeNodeObject,
+    index: Int
+) {
+    let container = TilingContainer(
+        parent: parent,
+        adaptiveWeight: frozenContainer.weight,
+        frozenContainer.orientation,
+        frozenContainer.layout,
+        index: index
+    )
+
+    for (i, child) in frozenContainer.children.enumerated() {
+        switch child {
+            case .window(let w):
+                if let window = MacWindow.get(byId: w.id) {
+                    window.bind(to: container, adaptiveWeight: w.weight, index: i)
+                }
+            case .container(let c):
+                restoreTreeRecursiveAllowMissing(frozenContainer: c, parent: container, index: i)
+        }
+    }
+}

--- a/Sources/Common/model/Orientation.swift
+++ b/Sources/Common/model/Orientation.swift
@@ -1,4 +1,4 @@
-public enum Orientation: Sendable {
+public enum Orientation: String, Codable, Sendable {
     /// Windows are planced along the **horizontal** line
     /// x-axis
     case h


### PR DESCRIPTION
## Summary
- persist workspaces and layouts to `/tmp/<app-id>-workspace-state.json`
- restore previous layout on startup if possible
- store state after each refresh session
- add Codable conformance for `Orientation`, `Layout`, and Frozen structs

## Testing
- `./run-tests.sh` *(fails: ApplicationServices headers not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d1bc0e8648324bc2090d1f25575c5